### PR TITLE
update type config file to remove progressive-delivery type

### DIFF
--- a/frontend/config.d.ts
+++ b/frontend/config.d.ts
@@ -1,9 +1,1 @@
-export interface Config {
-  "progressive-delivery": {
-    /**
-     * The public absolute root URL that the frontend.
-     * @visibility frontend
-     */
-    "saas-promotions-json": string;
-  }
-}
+export interface Config {}


### PR DESCRIPTION
# Purpose

This value is not necessary anymore since we are retrieving the necessary data in a new way. This is blocking the release of the new pod to come up.