### PR TITLE
updating version of progressive delivery plugin

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -41,7 +41,7 @@
     "@backstage/theme": "^0.6.6",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
-    "@redhatinsights/backstage-plugin-progressive-delivery-frontend": "^0.2.1",
+    "@redhatinsights/backstage-plugin-progressive-delivery-frontend": "^0.3.0",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",
     "react-router": "^6.3.0",

--- a/plugins/progressive-delivery-frontend/package.json
+++ b/plugins/progressive-delivery-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redhatinsights/backstage-plugin-progressive-delivery-frontend",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10929,7 +10929,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@redhatinsights/backstage-plugin-progressive-delivery-frontend@npm:^0.2.1, @redhatinsights/backstage-plugin-progressive-delivery-frontend@workspace:plugins/progressive-delivery-frontend":
+"@redhatinsights/backstage-plugin-progressive-delivery-frontend@npm:^0.3.0, @redhatinsights/backstage-plugin-progressive-delivery-frontend@workspace:plugins/progressive-delivery-frontend":
   version: 0.0.0-use.local
   resolution: "@redhatinsights/backstage-plugin-progressive-delivery-frontend@workspace:plugins/progressive-delivery-frontend"
   dependencies:
@@ -15573,7 +15573,7 @@ __metadata:
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@playwright/test": "npm:^1.32.3"
-    "@redhatinsights/backstage-plugin-progressive-delivery-frontend": "npm:^0.2.1"
+    "@redhatinsights/backstage-plugin-progressive-delivery-frontend": "npm:^0.3.0"
     "@testing-library/dom": "npm:^9.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^14.0.0"


### PR DESCRIPTION
# Purpose

After refactoring the plugin to run as a local backstage plugin for testing, I forgot to up the version of the plugin. This PR sets the version to `v0.3.0`.