### PR TITLE
add link to grafana dashboard with logs

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -43,6 +43,9 @@ integrations:
     #   apiBaseUrl: https://ghe.example.net/api/v3
     #   token: ${GHE_TOKEN}
 
+grafana:
+  dashboardLink: ${GRAFANA_LOGS_URL}
+
 proxy:
   ### Example for how to add a proxy endpoint for the frontend.
   ### A typical reason to do this is to handle HTTPS and CORS for internal services.

--- a/plugins/progressive-delivery-frontend/config.d.ts
+++ b/plugins/progressive-delivery-frontend/config.d.ts
@@ -1,0 +1,13 @@
+export interface Config {
+  /**
+   * Progressive Delivery Configuration
+   * @visibility frontend
+   */
+  grafana: {
+    /**
+     * Grafana dasboard URL
+     * @visibility frontend
+     */
+    dashboardUrl: string;
+  };
+}

--- a/plugins/progressive-delivery-frontend/package.json
+++ b/plugins/progressive-delivery-frontend/package.json
@@ -67,6 +67,7 @@
     "ts-jest": "^29.1.3",
     "whatwg-fetch": "^3.6.20"
   },
+  "configSchema": "config.d.ts",
   "files": [
     "dist",
     "dist-scalprum"

--- a/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/NodeInfoComponent.tsx
+++ b/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/NodeInfoComponent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
+import { useApi, configApiRef } from '@backstage/core-plugin-api';
 import Dialog from '@material-ui/core/Dialog';
 import MuiDialogTitle from '@material-ui/core/DialogTitle';
 import MuiDialogContent from '@material-ui/core/DialogContent';
@@ -41,6 +42,11 @@ const DialogTitle = withStyles(styles)((props) => {
   }))(MuiDialogContent);
 
 export const NodeInfoComponent = ({ nodeData, isPopupOpen, handleClose }: { nodeData: any, isPopupOpen: boolean, handleClose: any }, ) => {
+  const config = useApi(configApiRef);
+  console.log("config", config)
+  const grafanaUrl = config.getString('grafana.dashboardLink');
+  console.log("grafanaUrl:", grafanaUrl);
+
   const handleCloseEvent = (event) => {
     handleClose(event.target.value)
   }

--- a/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/NodeInfoComponent.tsx
+++ b/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/NodeInfoComponent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { createStyles, makeStyles, withStyles } from '@material-ui/core/styles';
 import { useApi, configApiRef } from '@backstage/core-plugin-api';
 import Dialog from '@material-ui/core/Dialog';
 import MuiDialogTitle from '@material-ui/core/DialogTitle';
@@ -7,11 +7,16 @@ import MuiDialogContent from '@material-ui/core/DialogContent';
 import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
 import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
+import Box from '@material-ui/core/Box';
 
 const styles = (theme) => ({
     root: {
       margin: 0,
       padding: theme.spacing(2),
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center'
     },
     closeButton: {
       position: 'absolute',
@@ -20,6 +25,19 @@ const styles = (theme) => ({
       color: theme.palette.grey[500],
     },
 });
+
+// Grid styling
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      marginTop: "10px",
+      flexGrow: 1,
+    },
+    button: {
+      justifyContent: 'center'
+    },
+  }),
+);
 
 const DialogTitle = withStyles(styles)((props) => {
     const { children, classes, onClose, ...other } = props;
@@ -42,9 +60,11 @@ const DialogTitle = withStyles(styles)((props) => {
   }))(MuiDialogContent);
 
 export const NodeInfoComponent = ({ nodeData, isPopupOpen, handleClose }: { nodeData: any, isPopupOpen: boolean, handleClose: any }, ) => {
+  const classes = useStyles();
+
   const config = useApi(configApiRef);
   console.log("config", config)
-  const grafanaUrl = config.getString('grafana.dashboardLink');
+  const grafanaUrl = config.getString('grafana.dashboardUrl');
   console.log("grafanaUrl:", grafanaUrl);
 
   const handleCloseEvent = (event) => {
@@ -69,13 +89,17 @@ export const NodeInfoComponent = ({ nodeData, isPopupOpen, handleClose }: { node
 
   const DisplayNodeData = () => {
     return (
-        <div>
-            <CheckIsTest isTest={nodeData?.isTest} />
-            <Typography>Commit Sha: {nodeData?.commit_sha || "N/A"}</Typography>
-            <Typography>Cluster: {nodeData?.cluster}</Typography>
-            <Typography>Namespace: {nodeData?.namespace}</Typography>
-            <Typography>Deployment State: {nodeData?.deployment_state}</Typography>
-            <Typography>Saas: {nodeData?.saas}</Typography>
+        <div className={classes.root}>
+          <CheckIsTest isTest={nodeData?.isTest} />
+          <Typography>Commit Sha: {nodeData?.commit_sha || "N/A"}</Typography>
+          <Typography>Cluster: {nodeData?.cluster}</Typography>
+          <Typography>Namespace: {nodeData?.namespace}</Typography>
+          <Typography>Deployment State: {nodeData?.deployment_state}</Typography>
+          <Typography>Saas: {nodeData?.saas}</Typography>
+
+          <Box textAlign='center'>
+            <Button href={grafanaUrl} variant="contained" target="_blank">Logs</Button>
+          </Box>
         </div>
     )
   }

--- a/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/ProgressiveDeliveryComponent.tsx
+++ b/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/ProgressiveDeliveryComponent.tsx
@@ -90,6 +90,11 @@ export const TopologyComponent = () => {
   const baseUrl = config.getString('backend.baseUrl');
   const fetchApi = useApi(fetchApiRef);
 
+
+  console.log("config", config)
+  const grafanaUrl = config.getString('grafana.dashboardUrl');
+  console.log("grafanaUrl:", grafanaUrl);
+
   const querySaasPromotionsData = () => {
     setIsLoading(true);
     setError(false);


### PR DESCRIPTION
# Purpose

This PR adds a grafana link that will display logs for a given job. This link will be visible when a user clicks a node in the UI. 