### PR TITLE
fixed issue populating the data

### DIFF
--- a/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/ProgressiveDeliveryComponent.tsx
+++ b/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/ProgressiveDeliveryComponent.tsx
@@ -186,7 +186,7 @@ export const TopologyComponent = () => {
     const paddedHeight = height + padding * 2;
 
     if (id.match(new RegExp(`^${MANY_TO_MANY_NODE_LABEL}-\\d+$`))) {
-      const classes = useStyles(node.deployment_state);
+      const classes = useStyles();
       return (
         <g>
           <rect


### PR DESCRIPTION
# Purpose

This patch fixes a bug that would display the following error in the browser dev console:
```
ReferenceError: can't access lexical declaration 'p' before initialization
```

We did not need to pass the node's `deployment_state` to that styling function.