### PR TITLE
Clicking node text will open popup

### DIFF
--- a/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/ProgressiveDeliveryComponent.tsx
+++ b/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/ProgressiveDeliveryComponent.tsx
@@ -265,6 +265,7 @@ export const TopologyComponent = () => {
           x={paddedWidth * 2}
           textAnchor="middle"
           alignmentBaseline="middle"
+          onClick={() => handleNodeClick(entity, node)}
         >
           {tspans}
         </text>


### PR DESCRIPTION
# Purpose

This PR allows a user to click anywhere in the node - now with the text - to open the info about the pipeline run. This is just a QOL improvement. 