### PR TITLE
`DependencyGraph` component renders nodes/edges only if lengths of each are greater than 0

### DIFF
--- a/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/ProgressiveDeliveryComponent.tsx
+++ b/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/ProgressiveDeliveryComponent.tsx
@@ -296,7 +296,6 @@ export const TopologyComponent = () => {
   }
 
   if (nodes.length > 0 && edges.length > 0) {
-    console.log("length:", nodes.length)
     return (
       <InfoCard title="Progressive Delivery Topology">
         <NodeInfoComponent nodeData={selectedNode} isPopupOpen={isPopupOpen} handleClose={handleClose} />

--- a/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/ProgressiveDeliveryComponent.tsx
+++ b/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/ProgressiveDeliveryComponent.tsx
@@ -295,7 +295,8 @@ export const TopologyComponent = () => {
     );
   }
 
-  if (nodes.length !== 0 && edges.length !== 0) {
+  if (nodes.length > 0 && edges.length > 0) {
+    console.log("length:", nodes.length)
     return (
       <InfoCard title="Progressive Delivery Topology">
         <NodeInfoComponent nodeData={selectedNode} isPopupOpen={isPopupOpen} handleClose={handleClose} />


### PR DESCRIPTION
# Purpose

An initial render of the `DependencyGraph` would occur before all data was gathered. This would cause an error with populating the `DependencyGraph` since the length of `nodes` and `edges` would be empty. This PR fixes the if-statement to ensure that the value of the lengths for the `nodes` and `edges` are greater than 0. During multiple renders of the component, it starts off set as `undefined` then will get set to `0` before actually getting populated with the data. 