### PR TITLE
Adding alert to tell users they can click a node for more information

### DIFF
--- a/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/ProgressiveDeliveryComponent.tsx
+++ b/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/ProgressiveDeliveryComponent.tsx
@@ -304,7 +304,7 @@ export const TopologyComponent = () => {
   if (nodes.length > 0 && edges.length > 0) {
     return (
       <InfoCard title="Progressive Delivery Topology">
-        <Alert severity="info">Click the nodes for more information on the job run</Alert>
+        <Alert severity="info">Click the nodes for more information on each job run</Alert>
         <NodeInfoComponent nodeData={selectedNode} isPopupOpen={isPopupOpen} handleClose={handleClose} />
         <DependencyGraph
           nodes={nodes}

--- a/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/ProgressiveDeliveryComponent.tsx
+++ b/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/ProgressiveDeliveryComponent.tsx
@@ -6,6 +6,7 @@ import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
 import { NodeInfoComponent } from './NodeInfoComponent';
 import Tooltip from '@material-ui/core/Tooltip';
 import { Entity } from '@backstage/catalog-model';
+import Alert from '@material-ui/lab/Alert';
 
 const MANY_TO_MANY_NODE_LABEL = "soak";
 
@@ -303,6 +304,7 @@ export const TopologyComponent = () => {
   if (nodes.length > 0 && edges.length > 0) {
     return (
       <InfoCard title="Progressive Delivery Topology">
+        <Alert severity="info">Click the nodes for more information on the job run</Alert>
         <NodeInfoComponent nodeData={selectedNode} isPopupOpen={isPopupOpen} handleClose={handleClose} />
         <DependencyGraph
           nodes={nodes}


### PR DESCRIPTION
# Purpose

Adds an `Alert` component that informs the user about clicking the nodes to get more info on job runs.

<img width="1253" alt="Screenshot 2025-06-19 at 11 42 08 AM" src="https://github.com/user-attachments/assets/1c900bdd-489f-4f8c-ae7f-cf098d096791" />
