### PR TITLE
temporarily removing link to grafana dashboard

### DIFF
--- a/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/NodeInfoComponent.tsx
+++ b/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/NodeInfoComponent.tsx
@@ -95,10 +95,11 @@ export const NodeInfoComponent = ({ nodeData, isPopupOpen, handleClose }: { node
           <Typography>Cluster: {nodeData?.cluster}</Typography>
           <Typography>Namespace: {nodeData?.namespace}</Typography>
           <Typography>Deployment State: {nodeData?.deployment_state}</Typography>
-          <Typography>Saas: {nodeData?.saas}</Typography> 
-          {/* <Box textAlign='center'>
+          <Typography>Saas: {nodeData?.saas}</Typography>
+
+          {/*<Box textAlign='center'>
             <Button href={grafanaUrl} variant="contained" target="_blank">Logs</Button>
-          </Box> */}
+          </Box>*/}
         </div>
     )
   }

--- a/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/NodeInfoComponent.tsx
+++ b/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/NodeInfoComponent.tsx
@@ -96,7 +96,7 @@ export const NodeInfoComponent = ({ nodeData, isPopupOpen, handleClose }: { node
           <Typography>Namespace: {nodeData?.namespace}</Typography>
           <Typography>Deployment State: {nodeData?.deployment_state}</Typography>
           <Typography>Saas: {nodeData?.saas}</Typography>
-          
+ 
           {/* <Box textAlign='center'>
             <Button href={grafanaUrl} variant="contained" target="_blank">Logs</Button>
           </Box> */}

--- a/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/NodeInfoComponent.tsx
+++ b/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/NodeInfoComponent.tsx
@@ -95,8 +95,7 @@ export const NodeInfoComponent = ({ nodeData, isPopupOpen, handleClose }: { node
           <Typography>Cluster: {nodeData?.cluster}</Typography>
           <Typography>Namespace: {nodeData?.namespace}</Typography>
           <Typography>Deployment State: {nodeData?.deployment_state}</Typography>
-          <Typography>Saas: {nodeData?.saas}</Typography>
- 
+          <Typography>Saas: {nodeData?.saas}</Typography> 
           {/* <Box textAlign='center'>
             <Button href={grafanaUrl} variant="contained" target="_blank">Logs</Button>
           </Box> */}

--- a/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/NodeInfoComponent.tsx
+++ b/plugins/progressive-delivery-frontend/src/components/ProgressiveDeliveryComponent/NodeInfoComponent.tsx
@@ -96,10 +96,10 @@ export const NodeInfoComponent = ({ nodeData, isPopupOpen, handleClose }: { node
           <Typography>Namespace: {nodeData?.namespace}</Typography>
           <Typography>Deployment State: {nodeData?.deployment_state}</Typography>
           <Typography>Saas: {nodeData?.saas}</Typography>
-
-          <Box textAlign='center'>
+          
+          {/* <Box textAlign='center'>
             <Button href={grafanaUrl} variant="contained" target="_blank">Logs</Button>
-          </Box>
+          </Box> */}
         </div>
     )
   }


### PR DESCRIPTION
# Purpose

At the moment we don't have all the correct data to dynamically create the correct grafana link to the logs. While we wait, I am removing the button that links out to grafana. 